### PR TITLE
Refactor endpoints

### DIFF
--- a/src/sciwyrm/main.py
+++ b/src/sciwyrm/main.py
@@ -20,13 +20,7 @@ from .templates import (
     notebook_template_path,
 )
 
-import logging
-
 app = FastAPI()
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler())
 
 
 @app.get("/livez", response_description="The service is alive")
@@ -39,7 +33,7 @@ async def livez() -> str:
 async def list_templates(
     config: Annotated[AppConfig, Depends(app_config)]
 ) -> list[notebook.TemplateSummary]:
-    logger.info("Templates")
+    """Return a list of all available templates."""
     """Return a list of available notebook templates."""
     return notebook.available_templates(config)
 
@@ -75,7 +69,6 @@ async def format_notebook_from_json(
     templates: Annotated[Jinja2Templates, Depends(get_templates)],
     spec: notebook.NotebookSpecWithConfig = Depends(_inject_app_config),  # noqa: B008
 ) -> Response:
-
     """Format and return a notebook."""
     formatted = templates.TemplateResponse(
         name=notebook_template_path(spec.template_id),

--- a/src/sciwyrm/main.py
+++ b/src/sciwyrm/main.py
@@ -5,6 +5,7 @@
 import json
 from typing import Annotated
 
+import uvicorn
 from fastapi import Depends, FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -19,13 +20,28 @@ from .templates import (
     notebook_template_path,
 )
 
+import logging
+
 app = FastAPI()
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
 
-@app.get("/notebook/templates", response_description="Available templates")
+
+@app.get("/alive", response_description="The service is alive")
+async def list_templates(
+    config: Annotated[AppConfig, Depends(app_config)]
+) -> bool:
+    """Return a list of available notebook templates."""
+    return True
+
+
+@app.get("/templates", response_description="Available templates")
 async def list_templates(
     config: Annotated[AppConfig, Depends(app_config)]
 ) -> list[notebook.TemplateSummary]:
+    logger.info("Templates")
     """Return a list of available notebook templates."""
     return notebook.available_templates(config)
 
@@ -56,11 +72,12 @@ async def template_schema(
 
 
 @app.post("/notebook", response_model=dict, response_description="Rendered notebook")
-async def format_notebook(
+async def format_notebook_from_json(
     request: Request,
     templates: Annotated[Jinja2Templates, Depends(get_templates)],
     spec: notebook.NotebookSpecWithConfig = Depends(_inject_app_config),  # noqa: B008
 ) -> Response:
+
     """Format and return a notebook."""
     formatted = templates.TemplateResponse(
         name=notebook_template_path(spec.template_id),
@@ -70,3 +87,7 @@ async def format_notebook(
     nb = json.loads(formatted.body)
     notebook.insert_notebook_metadata(nb, spec)
     return JSONResponse(nb)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/sciwyrm/main.py
+++ b/src/sciwyrm/main.py
@@ -29,12 +29,10 @@ logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler())
 
 
-@app.get("/alive", response_description="The service is alive")
-async def list_templates(
-    config: Annotated[AppConfig, Depends(app_config)]
-) -> bool:
-    """Return a list of available notebook templates."""
-    return True
+@app.get("/livez", response_description="The service is alive")
+async def livez() -> str:
+    """Return 200 if the serve is alive."""
+    return "ok"
 
 
 @app.get("/templates", response_description="Available templates")


### PR DESCRIPTION
This PR adds the `alive` endpoint which is useful when deploying with an orchestration tool like kubernetes and docker and renamed the `notebook/templates` to just `templates`