### PR TITLE
Insert a metadata cell

### DIFF
--- a/src/sciwyrm/main.py
+++ b/src/sciwyrm/main.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 SciCat Project (https://github.com/SciCatProject/sciwyrm)
-"""The SciWym application."""
+# Copyright (c) 2025 SciCat Project (https://github.com/SciCatProject/sciwyrm)
+"""The SciWyrm application."""
 
 import json
 from typing import Annotated
@@ -57,5 +57,5 @@ async def format_notebook(
         context=notebook.render_context(spec),
     )
     nb = json.loads(formatted.body)
-    nb["metadata"]["sciwyrm"] = notebook.notebook_metadata(spec)
+    notebook.insert_notebook_metadata(nb, spec)
     return JSONResponse(nb)

--- a/src/sciwyrm/notebook.py
+++ b/src/sciwyrm/notebook.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 SciCat Project (https://github.com/SciCatProject/sciwyrm)
+# Copyright (c) 2025 SciCat Project (https://github.com/SciCatProject/sciwyrm)
 """Notebook handling."""
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -117,3 +118,27 @@ def notebook_metadata(spec: NotebookSpecWithConfig) -> dict[str, Any]:
         "template_rendered_at": datetime.now(tz=timezone.utc).isoformat(),
         "template_hash": spec.config.template_hash,
     }
+
+
+def insert_notebook_metadata(
+    notebook: dict[str, Any], spec: NotebookSpecWithConfig
+) -> None:
+    """Insert template metadata into a rendered notebook."""
+    metadata = notebook_metadata(spec)
+    notebook["metadata"]["sciwyrm"] = metadata
+    notebook["cells"].insert(
+        0,
+        {
+            "cell_type": "markdown",
+            "id": uuid.uuid4().hex[:16],
+            "metadata": {},
+            "source": [
+                '<div style="font-size:x-small;padding-left:10pt">\n',
+                f"<span style=\"color:rgba(128,128,128,128)\">Template:</span> {metadata['template_submission_name']}<br>\n",  # noqa: E501
+                f"<span style=\"color:rgba(128,128,128,128)\">Id:</span> {metadata['template_id']} "  # noqa: E501
+                f"<span style=\"color: rgba(128,128,128,128);margin-left:10pt\"|>Version:</span> {metadata['template_version']} "  # noqa: E501
+                f"<span style=\"color: rgba(128,128,128,128);margin-left:10pt\"|>Rendered at:</span> {metadata['template_rendered_at']}\n",  # noqa: E501
+                "</div>",
+            ],
+        },
+    )

--- a/templates/notebook/b32f6992-0355-4759-b780-ececd4957c23.ipynb
+++ b/templates/notebook/b32f6992-0355-4759-b780-ececd4957c23.ipynb
@@ -6,14 +6,7 @@
    "metadata": {},
    "source": [
     "# {{ TEMPLATE_DISPLAY_NAME | capitalize }}\n",
-    "<span style=\"font-size: smaller\">Notebook generated from template '<em>{{ TEMPLATE_DISPLAY_NAME }}</em>' version {{ TEMPLATE_VERSION }} (id: `{{ TEMPLATE_ID }}`, time: <time>{{ TEMPLATE_RENDERED_AT }}</time>).</span>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9e7442fc9ec68975",
-   "metadata": {},
-   "source": [
+    "\n",
     "This notebook downloads selected datasets from SciCat and all files for those datasets."
    ]
   },


### PR DESCRIPTION
This inserts an extra cell at the start of each notebook showing some metadata about the template. This results in nicer output than the previous version and ensures that the metadata is always present.